### PR TITLE
fixed cloud shadows displaying over transparent objects

### DIFF
--- a/Atmosphere/Clouds2D.cs
+++ b/Atmosphere/Clouds2D.cs
@@ -160,6 +160,7 @@ namespace Atmosphere
                 ShadowProjector.transform.parent = celestialBody.transform;
                 ShadowProjector.material = new Material(CloudShadowShader);
                 shadowMaterial.ApplyMaterialProperties(ShadowProjector.material);
+                ShadowProjector.material.renderQueue = (int)Tools.Queue.Geometry + 500;
             }
 
 


### PR DESCRIPTION
I fixed the issue with cloud shadows drawing over clouds and other transparent objects (ie scatterer atmosphere).

The issue in question is visible here: http://i.imgur.com/vK2IkEW.jpg

-blackrack
