### PR TITLE
Properly scale the clouds in modified main menus

### DIFF
--- a/Atmosphere/Clouds2D.cs
+++ b/Atmosphere/Clouds2D.cs
@@ -82,6 +82,9 @@ namespace Atmosphere
         public float Altitude() { return celestialBody == null ? radius : (float)(radius - celestialBody.Radius); }
         float radiusScaleLocal;
         private bool isMainMenu = false;
+        
+        // Used to calculate the scale of the clouds in the mainmenu
+        private const float joolRadius = 6000000f;
 
         private static Shader cloudShader = null;
 
@@ -198,7 +201,7 @@ namespace Atmosphere
             float localScale;
             if (isMainMenu)
             {
-                localScale = worldScale * 10f;
+                localScale = worldScale * (joolRadius / (float) celestialBody.Radius);
             }
             else
             {


### PR DESCRIPTION
If you replace the body in the main menu using Kopernicus, the scale of the clouds is messed up for bodies that don't have the same size as Kerbin.

For example Eve, which is bigger than Kerbin, has it's clouds floating multiple kilometers above the planet model, while Laythe's clouds are completely missing, since Laythe is smaller than Kerbin. 
The reason for this is, that Kopernicus has to rescale the bodies in the main menu to match the exact size of Kerbin. (i.e. a radius of 600000m or 100 scaled space units).

Since EVE cannot really know which body is represented in the main menu, it always assumes the scale of Kerbin for the clouds. However, in combination with using the (changed) planet radius this seems to causes the described bug.

The solution I came up with is to change the hardcoded Kerbin scale to a dynamically calculated scale in the main menu. This yields the same results for Kerbin, and accurate results for every other body.