### PR TITLE
Cull zero-alpha volumetric particles

### DIFF
--- a/Assets/Shaders/CloudVolumeParticle.shader
+++ b/Assets/Shaders/CloudVolumeParticle.shader
@@ -144,10 +144,10 @@ Shader "EVE/CloudVolumeParticle" {
 
 
 					float4 mvCenter = mul(UNITY_MATRIX_MV, localOrigin);
-					o.pos = mul(UNITY_MATRIX_P,
-					mvCenter
-					+ float4(v.vertex.xyz*localScale,v.vertex.w));
-
+					
+					o.pos = mul(UNITY_MATRIX_P,mvCenter+ float4(v.vertex.xyz*localScale,v.vertex.w));
+					o.pos.z = o.color.a > (1.0/255.0) ? o.pos.z : -o.pos.w; //cull vertex if low alpha z/w = -1, behind far plane. source: Siggraph 2012, Creating vast game worlds (just cause 2)
+					
 					float2 texcoodOffsetxy = ((2*v.texcoord)- 1);
 					float4 texcoordOffset = float4(texcoodOffsetxy.x, texcoodOffsetxy.y, 0, v.vertex.w);
 


### PR DESCRIPTION
Hello,

A small pull request to cull zero-alpha particles in the vertex shader:
Since we have the alpha value already in the vertex shader, this approach allows us to save some fragment shader work and some fillrate.

I haven't tested with EVE alone, but with EVE+scatterer I saw up to 12% performance increase in cases where there are lots of zero-alpha particles on screen (ie an empty area in the clouds). Results may vary with EVE alone as the strain on the GPU may not be as high and we may be more CPU-limited. Not a big performance boost overall but anything helps.

The vertex culling is described here in page 29: http://www.humus.name/Articles/Persson_CreatingVastGameWorlds.pdf

-blackrack