### PR TITLE
fix zero-alpha particle vertex culling on opengl

### DIFF
--- a/Assets/Shaders/CloudVolumeParticle.shader
+++ b/Assets/Shaders/CloudVolumeParticle.shader
@@ -146,7 +146,7 @@ Shader "EVE/CloudVolumeParticle" {
 					float4 mvCenter = mul(UNITY_MATRIX_MV, localOrigin);
 					
 					o.pos = mul(UNITY_MATRIX_P,mvCenter+ float4(v.vertex.xyz*localScale,v.vertex.w));
-					o.pos.z = o.color.a > (1.0/255.0) ? o.pos.z : -o.pos.w; //cull vertex if low alpha z/w = -1, behind far plane. source: Siggraph 2012, Creating vast game worlds (just cause 2)
+					o.pos = o.color.a > (1.0/255.0) ? o.pos : float4(2.0, 2.0, 2.0, 1.0); //cull vertex if low alpha, pos outside clipspace
 					
 					float2 texcoodOffsetxy = ((2*v.texcoord)- 1);
 					float4 texcoordOffset = float4(texcoodOffsetxy.x, texcoodOffsetxy.y, 0, v.vertex.w);


### PR DESCRIPTION
Hello,

The previous culling approach wasn't working on opengl, this is a similar culling approach that works by sending zero-alpha particle's vertexes outside the clip space, it's working correctly in opengl.

-blackrack