### PR TITLE
Fix version file URL property and version max

### DIFF
--- a/ContentEVE/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements.version
+++ b/ContentEVE/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "Environmental Visual Enhancements",
-	"URL": "https://raw.githubusercontent.com/WazWaz/EnvironmentalVisualEnhancements/master/EnvironmentalVisualEnhancements.version",
+	"URL": "https://github.com/WazWaz/EnvironmentalVisualEnhancements/raw/master/ContentEVE/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements.version",
 	"DOWNLOAD" : "https://github.com/WazWaz/EnvironmentalVisualEnhancements/releases",
 	"GITHUB": {
 		"USERNAME": "WazWaz",
@@ -25,7 +25,6 @@
 	},
 	"KSP_VERSION_MAX": {
 		"MAJOR": 1,
-		"MINOR": 4,
-		"PATCH": 99
+		"MINOR": 7
 	}
 }


### PR DESCRIPTION
The URL property of the current version file leads to a 404 not found error:
- https://raw.githubusercontent.com/WazWaz/EnvironmentalVisualEnhancements/master/EnvironmentalVisualEnhancements.version

Now it's fixed.

Folks on the forum thread report that this mod still works in KSP 1.6 and 1.7, but the version file only goes up to 1.4.
Now the KSP version max is 1.7. (If the version file in the current download had a valid URL property, this change would mark the current release as supported up to 1.7.)

Would it be OK with you if we marked this mod as supporting up to KSP 1.7 in the CKAN metadata? I don't want to do that if it isn't officially supported and therefore might lead to bad bug reports for you.